### PR TITLE
Prevent sending non-thread-safe T to another thread

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,7 +693,7 @@ impl<T> Clone for NodePtr<T> {
 }
 
 impl<T> Copy for NodePtr<T> {}
-unsafe impl<T> Send for NodePtr<T> {}
+unsafe impl<T> Send for NodePtr<T> where T: Send {}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
This fixes a soundness bug where a `Sender<Rc<()>>` (for example) could
be sent to another thread, and then used to send an `Rc<()>` across
threads unsafely.